### PR TITLE
album art cache fix

### DIFF
--- a/src/lib/stores/player-store.ts
+++ b/src/lib/stores/player-store.ts
@@ -1,5 +1,6 @@
 import type { Song } from "$lib/types";
 import { writable } from "svelte/store";
+import { persisted } from 'svelte-persisted-store';
 
 export const currentPlayingSong = writable<Song>({
     artist: null,
@@ -7,8 +8,14 @@ export const currentPlayingSong = writable<Song>({
     album: null
 });
 
-export const playTime = writable<number>(0);
+export const cachedAlbumArt = persisted<Record<string, string>>('cachedAlbumArt', {}, {
+    storage: 'local',
+    syncTabs: true
+});
+
 export const albumArt = writable('');
 export const accentColor = writable('#ffffff');
 export const textColor = writable('#000000');
 export const isLoading = writable(false);
+export const playTime = writable(0);
+export const duration = writable(0);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Lyrics from '$lib/components/Lyrics.svelte';
+	import { playTime, duration } from '$lib/stores/player-store';
 </script>
 
 <Lyrics />


### PR DESCRIPTION
This pull request introduces caching for album art to improve performance and reduce redundant API calls. The main changes include adding a caching mechanism, updating imports, and modifying the `getAlbumArt` function to utilize the cache.

Caching mechanism:

* [`src/lib/player.ts`](diffhunk://#diff-d056c509c8b2fbde8fb7c4e54186d542d98a6886cf9767106a8bb7ed1830c6deL7-R8): Added `cachedAlbumArt` to the imports and implemented a caching system in the `getAlbumArt` function. The function now checks the cache before making an API call and caches the retrieved album art in base64 format. [[1]](diffhunk://#diff-d056c509c8b2fbde8fb7c4e54186d542d98a6886cf9767106a8bb7ed1830c6deL7-R8) [[2]](diffhunk://#diff-d056c509c8b2fbde8fb7c4e54186d542d98a6886cf9767106a8bb7ed1830c6deR109-R174)

Store updates:

* [`src/lib/stores/player-store.ts`](diffhunk://#diff-53871427a0154d4a479e37568ee3b192dd8c112bac29d0f4740545f5ceda8c52R3-R21): Introduced a new `cachedAlbumArt` store using `svelte-persisted-store` to persist cached album art across sessions and synchronize across tabs.

Additional imports:

* [`src/lib/player.ts`](diffhunk://#diff-d056c509c8b2fbde8fb7c4e54186d542d98a6886cf9767106a8bb7ed1830c6deR20): Added the `get` function from `svelte/store` to access the cached album art.

Component updates:

* [`src/routes/+page.svelte`](diffhunk://#diff-1e1270da740e81dd13f8a65057582b0fce8a5fb3817ef913f3e90d7f82c4e9dfR3): Imported `playTime` and `duration` from `player-store` to manage playback state.
