### PR TITLE
Version sync

### DIFF
--- a/.github/workflows/homebrew-tap.yml
+++ b/.github/workflows/homebrew-tap.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 3.0.0 or v3.0.0)"
-        required: true
+        description: "Release version (optional; defaults to latest release)"
+        required: false
         type: string
 
 jobs:
@@ -19,17 +19,26 @@ jobs:
     steps:
       - name: Resolve version and release
         id: release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            VERSION="${{ github.event.inputs.version }}"
-            VERSION="${VERSION#v}"
+            INPUT_VERSION="${{ github.event.inputs.version }}"
+            if [ -z "$INPUT_VERSION" ]; then
+              TAG=$(gh release view latest --repo ${{ github.repository }} --json tagName -q .tagName)
+              [ -z "$TAG" ] && { echo "::error::No latest release found"; exit 1; }
+            else
+              TAG="${INPUT_VERSION#v}"
+              TAG="v${TAG}"
+            fi
+            VERSION="${TAG#v}"
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
+            echo "tag=${TAG}" >> $GITHUB_OUTPUT
           else
-            VERSION="${{ github.event.release.tag_name }}"
-            VERSION="${VERSION#v}"
+            TAG="${{ github.event.release.tag_name }}"
+            VERSION="${TAG#v}"
             echo "version=${VERSION}" >> $GITHUB_OUTPUT
-            echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+            echo "tag=${TAG}" >> $GITHUB_OUTPUT
           fi
 
       - name: Get macOS asset

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,11 @@ jobs:
         with:
           version: 8.15.7
 
+      - name: Sync version to package.json, tauri.conf.json, and Cargo.toml
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          node scripts/sync-version.mjs "${V#v}"
+
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
           version: 8.15.7
 
       - name: Sync version to package.json, tauri.conf.json, and Cargo.toml
+        shell: bash
         run: |
           V="${{ steps.version.outputs.version }}"
           node scripts/sync-version.mjs "${V#v}"

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
 	"version": "2.0.4",
 	"private": true,
 	"scripts": {
+		"sync-version": "node scripts/sync-version.mjs",
 		"dev": "vite dev",
 		"build": "vite build",
 		"preview": "vite preview",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Writes version to tauri.conf.json, package.json, and src-tauri/Cargo.toml.
+ * Usage: node scripts/sync-version.mjs [version]
+ *   If version is omitted, reads from src-tauri/tauri.conf.json and syncs to the others.
+ *   If version is given (e.g. 3.0.0), writes to all three.
+ */
+import { readFileSync, writeFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const tauriConfPath = join(root, "src-tauri", "tauri.conf.json");
+const packagePath = join(root, "package.json");
+const cargoPath = join(root, "src-tauri", "Cargo.toml");
+
+let version = process.argv[2];
+if (!version) {
+  const tauri = JSON.parse(readFileSync(tauriConfPath, "utf8"));
+  version = tauri.version;
+  if (!version) {
+    console.error("No version in tauri.conf.json and none passed as argument.");
+    process.exit(1);
+  }
+}
+version = version.replace(/^v/, "");
+
+// tauri.conf.json
+const tauri = JSON.parse(readFileSync(tauriConfPath, "utf8"));
+tauri.version = version;
+writeFileSync(tauriConfPath, JSON.stringify(tauri, null, "\t") + "\n");
+
+// package.json
+const pkg = JSON.parse(readFileSync(packagePath, "utf8"));
+pkg.version = version;
+writeFileSync(packagePath, JSON.stringify(pkg, null, "\t") + "\n");
+
+// Cargo.toml: replace first version = "..." in [package]
+const cargo = readFileSync(cargoPath, "utf8");
+const cargoUpdated = cargo.replace(/^version\s*=\s*"[^"]+"/m, `version = "${version}"`);
+writeFileSync(cargoPath, cargoUpdated);
+
+console.log("Synced version to", version);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -50,7 +50,7 @@
 			"exceptionDomain": "",
 			"frameworks": [],
 			"providerShortName": null,
-			"signingIdentity": "null"
+			"signingIdentity": null
 		},
 		"resources": [],
 		"shortDescription": "Get synchronized song lyrics.",


### PR DESCRIPTION
This pull request introduces a new script and workflow improvements to automatically synchronize the application version across `package.json`, `tauri.conf.json`, and `Cargo.toml`. It also updates the GitHub Actions workflows to make version handling more robust and flexible, especially for release automation.

**Version synchronization and automation improvements:**

* Added a new script `scripts/sync-version.mjs` that synchronizes the version number across `package.json`, `src-tauri/tauri.conf.json`, and `src-tauri/Cargo.toml`. This script can be run manually or as part of CI, ensuring all relevant files stay in sync.
* Added a `sync-version` npm script to `package.json` for easy invocation of the new version sync script.
* Updated the main GitHub Actions workflow (`main.yml`) to automatically run the version sync script after determining the release version, keeping all version fields consistent during CI/CD.

**Release workflow enhancements:**

* Improved the `homebrew-tap.yml` workflow to make the release version input optional, defaulting to the latest release if not provided. This makes manual and automated releases more flexible.
* Enhanced the version/tag resolution logic in `homebrew-tap.yml` to support both manual and automatic releases, and to handle version formatting more robustly.

**Other minor fixes:**

* Fixed the type of `signingIdentity` in `src-tauri/tauri.conf.json` from the string `"null"` to the proper JSON value `null`.